### PR TITLE
Fix error: unable to create a hosting account

### DIFF
--- a/app/config/config.php
+++ b/app/config/config.php
@@ -453,7 +453,7 @@ $config['csrf_token_name'] = 'nx_csrf_token';
 $config['csrf_cookie_name'] = 'csrf_cookie';
 $config['csrf_expire'] = 3600;
 $config['csrf_regenerate'] = FALSE;
-$config['csrf_exclude_uris'] = array('c/gogetssl', 'c/mofh');
+$config['csrf_exclude_uris'] = array('c/gogetssl', 'c/mofh', 'h/create_account');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
I fixed the problem that we can't create an account because when we click on check, POST return a 403 error and it's because CSRF protection is enable so I added this url to the whitelist